### PR TITLE
Making CRDs sensuMetadata consistent

### DIFF
--- a/example/asset/test-asset.yaml
+++ b/example/asset/test-asset.yaml
@@ -10,6 +10,7 @@ spec:
   url: https://s3.us-east-2.amazonaws.com/objectrocket-product-versions/sensu/assets/check-http.tar.gz
   sha512: 0c075f3a26735cb5a6afe06816471e7a6bf1dfb619204846e7697fdc00260ba046b4842959b90649c6cc54358d62239932e5c4d9dddba7c7fd257f8ac51b04fd
   clusterName: sensu
-  sensu_metadata:
-    name: platdev0
+  sensuMetadata:
+    name: sensu-asset-http
+    clusterName: platdev0
     namespace: default

--- a/example/checkconfig/test-checkconfig.yaml
+++ b/example/checkconfig/test-checkconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: objectrocket.com/v1beta1
 kind: SensuCheckConfig
 metadata:
-  name: sensu
+  name: sensu-checkconfig-google
   namespace: sensu
   finalizers:
   - checkconfig.finalizer.objectrocket.com
@@ -14,6 +14,7 @@ spec:
   interval: 15
   runtime_assets:
   - sensu-asset-http
-  sensu_metadata:
-    name: platdev0
+  sensuMetadata:
+    name: sensu-checkconfig-google
+    clusterName: platdev0
     namespace: default

--- a/example/example-sensu-cluster-objectrocket.yaml
+++ b/example/example-sensu-cluster-objectrocket.yaml
@@ -1,0 +1,25 @@
+apiVersion: objectrocket.com/v1beta1
+kind: SensuCluster
+metadata:
+  name: platdev0
+  namespace: sensu
+spec:
+  pod:
+    nodeSelector:
+      node-role.kubernetes.io/platform_worker: "true"
+    resources: {}
+    tolerations:
+    - effect: NoSchedule
+      key: node_role
+      operator: Equal
+      value: platform_worker
+    persistentVolumeClaimSpec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 8Gi
+      storageClassName: general
+  repository: sensu/sensu
+  size: 3
+  version: 5.1.0

--- a/pkg/apis/objectrocket/v1beta1/asset.go
+++ b/pkg/apis/objectrocket/v1beta1/asset.go
@@ -43,6 +43,7 @@ type SensuAsset struct {
 	Status SensuAssetStatus `json:"status"`
 }
 
+// SensuAssetSpec is the specification for a sensu asset
 type SensuAssetSpec struct {
 	// URL is the location of the asset
 	URL string `json:"url,omitempty"`
@@ -60,13 +61,14 @@ type SensuAssetSpec struct {
 
 	// Organization indicates to which org an asset belongs to
 	Organization string `json:"organization,omitempty"`
-	// Metadata contains the name, namespace, labels and annotations of the check
-	SensuMetadata ObjectMeta `json:"sensu_metadata,omitempty"`
+	// Metadata contains the sensu name, sensu namespace, sensu labels and sensu annotations of the check
+	SensuMetadata ObjectMeta `json:"sensuMetadata,omitempty"`
 }
 
 // SensuAssetStatus is the status of the sensu asset
 type SensuAssetStatus struct {
-	Accepted bool `json:"accepted"`
+	Accepted  bool   `json:"accepted"`
+	LastError string `json:"lastError"`
 }
 
 // ToAPISensuAsset returns a value of the SensuAsset type from the Sensu API

--- a/pkg/apis/objectrocket/v1beta1/backup_types.go
+++ b/pkg/apis/objectrocket/v1beta1/backup_types.go
@@ -18,16 +18,25 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
 	// AWS S3 related consts
-	BackupStorageTypeS3          BackupStorageType = "S3"
-	AWSSecretCredentialsFileName                   = "credentials"
-	AWSSecretConfigFileName                        = "config"
+
+	// BackupStorageTypeS3 is the backup storage type for ec2 s3
+	BackupStorageTypeS3 BackupStorageType = "S3"
+	// AWSSecretCredentialsFileName is the credentials file name
+	AWSSecretCredentialsFileName = "credentials"
+	// AWSSecretConfigFileName is the secret config name
+	AWSSecretConfigFileName = "config"
 
 	// Azure ABS related consts
-	BackupStorageTypeABS      BackupStorageType = "ABS"
-	AzureSecretStorageAccount                   = "storage-account"
-	AzureSecretStorageKey                       = "storage-key"
+
+	// BackupStorageTypeABS is the azure backup storage type
+	BackupStorageTypeABS BackupStorageType = "ABS"
+	// AzureSecretStorageAccount is the azure secret storage account name
+	AzureSecretStorageAccount = "storage-account"
+	// AzureSecretStorageKey is the azure secrets storage key
+	AzureSecretStorageKey = "storage-key"
 )
 
+// BackupStorageType is a backup storage type
 type BackupStorageType string
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/objectrocket/v1beta1/check_config.go
+++ b/pkg/apis/objectrocket/v1beta1/check_config.go
@@ -91,15 +91,16 @@ type SensuCheckConfigSpec struct {
 	// EnvVars is the list of environment variables to set for the check's
 	// execution environment.
 	EnvVars []string `json:"env_vars"`
-	// Metadata contains the name, namespace, labels and annotations of the check
-	SensuMetadata ObjectMeta `json:"sensu_metadata,omitempty"`
+	// Metadata contains the sensu name, sensu clusterName, sensu namespace, sensu labels and sensu annotations of the check
+	SensuMetadata ObjectMeta `json:"sensuMetadata,omitempty"`
 	// Validation is the OpenAPIV3Schema validation for sensu checks
 	Validation k8s_api_extensions_v1beta1.CustomResourceValidation `json:"validation,omitempty"`
 }
 
 // SensuCheckConfigStatus is the status of the sensu check config
 type SensuCheckConfigStatus struct {
-	Accepted bool `json:"accepted"`
+	Accepted  bool   `json:"accepted"`
+	LastError string `json:"lastError"`
 }
 
 // A ProxyRequests represents a request to execute a proxy check

--- a/pkg/apis/objectrocket/v1beta1/doc.go
+++ b/pkg/apis/objectrocket/v1beta1/doc.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1beta1 is the api spec for objectrocket sensu clusters
+//
 // +k8s:deepcopy-gen=package
 // +groupName=objectrocket.com
 package v1beta1

--- a/pkg/apis/objectrocket/v1beta1/handler.go
+++ b/pkg/apis/objectrocket/v1beta1/handler.go
@@ -53,8 +53,8 @@ type SensuHandlerSpec struct {
 	Filters       []string      `json:"filters"`
 	EnvVars       []string      `json:"envVars"`
 	RuntimeAssets []string      `json:"runtimeAssets"`
-	// Metadata contains the name, namespace, and labels of the handler
-	SensuMetadata ObjectMeta `json:"sensu_metadata,omitempty"`
+	// Metadata contains the sensu name, sensu namespace, sensu annotations, and sensu labels of the handler
+	SensuMetadata ObjectMeta `json:"sensuMetadata,omitempty"`
 	// Validation is the OpenAPIV3Schema validation for sensu assets
 	Validation k8s_api_extensions_v1beta1.CustomResourceValidation `json:"validation,omitempty"`
 }
@@ -67,7 +67,8 @@ type HandlerSocket struct {
 
 // SensuHandlerStatus is the status of the sensu handler
 type SensuHandlerStatus struct {
-	Accepted bool `json:"accepted"`
+	Accepted  bool   `json:"accepted"`
+	LastError string `json:"lastError"`
 }
 
 // ToSensuType returns a value of the Handler type from the Sensu API

--- a/pkg/apis/objectrocket/v1beta1/meta.go
+++ b/pkg/apis/objectrocket/v1beta1/meta.go
@@ -4,20 +4,22 @@ package v1beta1
 type ObjectMeta struct {
 	// Name must be unique within a namespace. Name is primarily intended for creation
 	// idempotence and configuration definition.
-	Name string `json:"name,omitempty" yaml: "name,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// ClusterName is the sensu cluster name within the kubernetes cluster
+	ClusterName string `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
 	// Namespace defines a logical grouping of objects within which each object name must
 	// be unique.
-	Namespace string `json:"namespace,omitempty" yaml: "namespace,omitempty"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	// Map of string keys and values that can be used to organize and categorize
 	// (scope and select) objects. May also be used in filters and token
 	// substitution.
 	// TODO: Link to Sensu documentation.
 	// More info: http://kubernetes.io/docs/user-guide/labels
-	Labels map[string]string `json:"labels,omitempty" yaml: ",labels,omitempty"`
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
 	// TODO: Link to Sensu documentation.
 	// More info: http://kubernetes.io/docs/user-guide/annotations
-	Annotations map[string]string `json:"annotations,omitempty" yaml: "annotations,omitempty" `
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty" `
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -204,3 +204,10 @@ func (c *Controller) initCRD() (err error) {
 	}
 	return
 }
+
+func (c *Controller) clusterExists(clusterName string) bool {
+	if _, ok := c.clusters[clusterName]; ok {
+		return true
+	}
+	return false
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -205,9 +205,7 @@ func (c *Controller) initCRD() (err error) {
 	return
 }
 
-func (c *Controller) clusterExists(clusterName string) bool {
-	if _, ok := c.clusters[clusterName]; ok {
-		return true
-	}
-	return false
+func (c *Controller) clusterExists(clusterName string) (ok bool) {
+	_, ok = c.clusters[clusterName]
+	return
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -329,7 +329,7 @@ func (s *InformerTestSuite) TestInformerWithOneCluster() {
 	cancelFunc()
 }
 
-func TestController_initCRD(t *testing.T) {
+func initInformers() (Informer, Informer, Informer) {
 	var (
 		assetInformer   Informer
 		checkInformer   Informer
@@ -344,6 +344,11 @@ func TestController_initCRD(t *testing.T) {
 	handlerInformer.indexer = fakeIndexer{}
 	handlerInformer.controller = fakeController{}
 	handlerInformer.queue = fakeQueue{}
+	return assetInformer, checkInformer, handlerInformer
+}
+
+func TestController_initCRD(t *testing.T) {
+	assetInformer, checkInformer, handlerInformer := initInformers()
 	type fields struct {
 		logger     *logrus.Entry
 		Config     Config

--- a/pkg/controller/informer_asset_test.go
+++ b/pkg/controller/informer_asset_test.go
@@ -1,0 +1,110 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	api "github.com/objectrocket/sensu-operator/pkg/apis/objectrocket/v1beta1"
+	"github.com/objectrocket/sensu-operator/pkg/cluster"
+	fakesensu "github.com/objectrocket/sensu-operator/pkg/generated/clientset/versioned/fake"
+	fakeapiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestController_syncSensuAsset(t *testing.T) {
+	assetInformer, checkInformer, handlerInformer := initInformers()
+	type fields struct {
+		logger     *logrus.Entry
+		Config     Config
+		informers  map[string]*Informer
+		finalizers map[string]cache.Indexer
+		clusters   map[string]*cluster.Cluster
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		asset    *api.SensuAsset
+		initFunc func(*testing.T, *Controller, *api.SensuAsset)
+		testFunc func(*Controller, *api.SensuAsset) error
+	}{
+		{
+			"test asset status is updated when cluster is missing",
+			fields{
+				logrus.WithField("pkg", "test"),
+				Config{
+					Namespace:         "testns",
+					ClusterWide:       true,
+					ServiceAccount:    "testsa",
+					KubeCli:           testclient.NewSimpleClientset(),
+					KubeExtCli:        fakeapiextensionsapiserver.NewSimpleClientset(),
+					SensuCRCli:        fakesensu.NewSimpleClientset(),
+					CreateCRD:         false,
+					WorkerThreads:     1,
+					ProcessingRetries: 0,
+				},
+				map[string]*Informer{},
+				map[string]cache.Indexer{},
+				map[string]*cluster.Cluster{},
+			},
+			&api.SensuAsset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testAsset",
+					Namespace: "sensu",
+				},
+				Spec: api.SensuAssetSpec{
+					URL:          "fake",
+					Sha512:       "fakeSHA",
+					Organization: "fakeOrg",
+					SensuMetadata: api.ObjectMeta{
+						Name:        "testAsset",
+						Namespace:   "default",
+						ClusterName: "doesntExist",
+					},
+				},
+			},
+			func(t *testing.T, c *Controller, a *api.SensuAsset) {
+				_, err := c.SensuCRCli.ObjectrocketV1beta1().SensuAssets("sensu").Create(a)
+				if err != nil {
+					t.Error(err)
+				}
+			},
+			func(c *Controller, a *api.SensuAsset) error {
+				c.syncSensuAsset(a)
+				k8sAsset, err := c.SensuCRCli.ObjectrocketV1beta1().SensuAssets("sensu").Get("testAsset", metav1.GetOptions{})
+				if err != nil {
+					return errors.New("failed to find asset in k8s")
+				}
+				if k8sAsset.Status.Accepted {
+					return errors.New("asset status should not be accepted=true")
+				}
+				if k8sAsset.Status.LastError == "" {
+					return errors.New("asset status lastError should not be empty")
+				}
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Controller{
+				logger:     tt.fields.logger,
+				Config:     tt.fields.Config,
+				informers:  tt.fields.informers,
+				finalizers: tt.fields.finalizers,
+				clusters:   tt.fields.clusters,
+			}
+			c.informers[api.SensuAssetResourcePlural] = &assetInformer
+			c.informers[api.SensuCheckConfigResourcePlural] = &checkInformer
+			c.informers[api.SensuHandlerResourcePlural] = &handlerInformer
+			tt.initFunc(t, c, tt.asset)
+			c.syncSensuAsset(tt.asset)
+			if err := tt.testFunc(c, tt.asset); err != nil {
+				t.Errorf("Controller.syncSensuAsset() error = %v", err)
+			}
+		})
+	}
+}

--- a/pkg/controller/informer_checkconfig_test.go
+++ b/pkg/controller/informer_checkconfig_test.go
@@ -1,0 +1,107 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	api "github.com/objectrocket/sensu-operator/pkg/apis/objectrocket/v1beta1"
+	"github.com/objectrocket/sensu-operator/pkg/cluster"
+	fakesensu "github.com/objectrocket/sensu-operator/pkg/generated/clientset/versioned/fake"
+	fakeapiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestController_syncSensuCheckConfig(t *testing.T) {
+	assetInformer, checkInformer, handlerInformer := initInformers()
+	type fields struct {
+		logger     *logrus.Entry
+		Config     Config
+		informers  map[string]*Informer
+		finalizers map[string]cache.Indexer
+		clusters   map[string]*cluster.Cluster
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		check    *api.SensuCheckConfig
+		initFunc func(*testing.T, *Controller, *api.SensuCheckConfig)
+		testFunc func(*Controller, *api.SensuCheckConfig) error
+	}{
+		{
+			"test checkconfig status is updated when cluster is missing",
+			fields{
+				logrus.WithField("pkg", "test"),
+				Config{
+					Namespace:         "testns",
+					ClusterWide:       true,
+					ServiceAccount:    "testsa",
+					KubeCli:           testclient.NewSimpleClientset(),
+					KubeExtCli:        fakeapiextensionsapiserver.NewSimpleClientset(),
+					SensuCRCli:        fakesensu.NewSimpleClientset(),
+					CreateCRD:         false,
+					WorkerThreads:     1,
+					ProcessingRetries: 0,
+				},
+				map[string]*Informer{},
+				map[string]cache.Indexer{},
+				map[string]*cluster.Cluster{},
+			},
+			&api.SensuCheckConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testCheckConfig",
+					Namespace: "sensu",
+				},
+				Spec: api.SensuCheckConfigSpec{
+					SensuMetadata: api.ObjectMeta{
+						Name:        "testCheckConfig",
+						Namespace:   "default",
+						ClusterName: "doesntExist",
+					},
+				},
+			},
+			func(t *testing.T, c *Controller, check *api.SensuCheckConfig) {
+				_, err := c.SensuCRCli.ObjectrocketV1beta1().SensuCheckConfigs("sensu").Create(check)
+				if err != nil {
+					t.Error(err)
+				}
+			},
+			func(c *Controller, check *api.SensuCheckConfig) error {
+				c.syncSensuCheckConfig(check)
+				k8sCheck, err := c.SensuCRCli.ObjectrocketV1beta1().SensuCheckConfigs("sensu").Get("testCheckConfig", metav1.GetOptions{})
+				if err != nil {
+					return errors.New("failed to find checkconfig in k8s")
+				}
+				if k8sCheck.Status.Accepted {
+					return errors.New("check status should not be accepted=true")
+				}
+				if k8sCheck.Status.LastError == "" {
+					return errors.New("check status lastError should not be empty")
+				}
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Controller{
+				logger:     tt.fields.logger,
+				Config:     tt.fields.Config,
+				informers:  tt.fields.informers,
+				finalizers: tt.fields.finalizers,
+				clusters:   tt.fields.clusters,
+			}
+			c.informers[api.SensuAssetResourcePlural] = &assetInformer
+			c.informers[api.SensuCheckConfigResourcePlural] = &checkInformer
+			c.informers[api.SensuHandlerResourcePlural] = &handlerInformer
+			tt.initFunc(t, c, tt.check)
+			c.syncSensuCheckConfig(tt.check)
+			if err := tt.testFunc(c, tt.check); err != nil {
+				t.Errorf("Controller.syncSensuCheck() error = %v", err)
+			}
+		})
+	}
+}

--- a/pkg/controller/informer_handler_test.go
+++ b/pkg/controller/informer_handler_test.go
@@ -1,0 +1,107 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	api "github.com/objectrocket/sensu-operator/pkg/apis/objectrocket/v1beta1"
+	"github.com/objectrocket/sensu-operator/pkg/cluster"
+	fakesensu "github.com/objectrocket/sensu-operator/pkg/generated/clientset/versioned/fake"
+	fakeapiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestController_syncSensuHandler(t *testing.T) {
+	assetInformer, checkInformer, handlerInformer := initInformers()
+	type fields struct {
+		logger     *logrus.Entry
+		Config     Config
+		informers  map[string]*Informer
+		finalizers map[string]cache.Indexer
+		clusters   map[string]*cluster.Cluster
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		handler  *api.SensuHandler
+		initFunc func(*testing.T, *Controller, *api.SensuHandler)
+		testFunc func(*Controller, *api.SensuHandler) error
+	}{
+		{
+			"test handler status is updated when cluster is missing",
+			fields{
+				logrus.WithField("pkg", "test"),
+				Config{
+					Namespace:         "testns",
+					ClusterWide:       true,
+					ServiceAccount:    "testsa",
+					KubeCli:           testclient.NewSimpleClientset(),
+					KubeExtCli:        fakeapiextensionsapiserver.NewSimpleClientset(),
+					SensuCRCli:        fakesensu.NewSimpleClientset(),
+					CreateCRD:         false,
+					WorkerThreads:     1,
+					ProcessingRetries: 0,
+				},
+				map[string]*Informer{},
+				map[string]cache.Indexer{},
+				map[string]*cluster.Cluster{},
+			},
+			&api.SensuHandler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testHandler",
+					Namespace: "sensu",
+				},
+				Spec: api.SensuHandlerSpec{
+					SensuMetadata: api.ObjectMeta{
+						Name:        "testHandler",
+						Namespace:   "default",
+						ClusterName: "doesntExist",
+					},
+				},
+			},
+			func(t *testing.T, c *Controller, handler *api.SensuHandler) {
+				_, err := c.SensuCRCli.ObjectrocketV1beta1().SensuHandlers("sensu").Create(handler)
+				if err != nil {
+					t.Error(err)
+				}
+			},
+			func(c *Controller, handler *api.SensuHandler) error {
+				c.syncSensuHandler(handler)
+				k8sHandler, err := c.SensuCRCli.ObjectrocketV1beta1().SensuHandlers("sensu").Get("testHandler", metav1.GetOptions{})
+				if err != nil {
+					return errors.New("failed to find handler in k8s")
+				}
+				if k8sHandler.Status.Accepted {
+					return errors.New("handler status should not be accepted=true")
+				}
+				if k8sHandler.Status.LastError == "" {
+					return errors.New("handler status lastError should not be empty")
+				}
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Controller{
+				logger:     tt.fields.logger,
+				Config:     tt.fields.Config,
+				informers:  tt.fields.informers,
+				finalizers: tt.fields.finalizers,
+				clusters:   tt.fields.clusters,
+			}
+			c.informers[api.SensuAssetResourcePlural] = &assetInformer
+			c.informers[api.SensuCheckConfigResourcePlural] = &checkInformer
+			c.informers[api.SensuHandlerResourcePlural] = &handlerInformer
+			tt.initFunc(t, c, tt.handler)
+			c.syncSensuHandler(tt.handler)
+			if err := tt.testFunc(c, tt.handler); err != nil {
+				t.Errorf("Controller.syncSensuHandler() error = %v", err)
+			}
+		})
+	}
+}

--- a/pkg/sensu_client/client_test.go
+++ b/pkg/sensu_client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"testing"
+	"time"
 
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/client"
@@ -170,6 +171,7 @@ func TestSensuClient_ensureCredentials(t *testing.T) {
 		},
 	}
 	sensuCliClient := client.New(&conf)
+
 	logger := logrus.WithFields(logrus.Fields{
 		"component": "cli-client",
 	})
@@ -221,6 +223,7 @@ func TestSensuClient_ensureCredentials(t *testing.T) {
 				clusterName: tt.fields.clusterName,
 				namespace:   tt.fields.namespace,
 				sensuCli:    tt.fields.sensuCli,
+				timeout:     2 * time.Second,
 			}
 			if err := s.ensureCredentials(); (err != nil) != tt.wantErr {
 				t.Errorf("SensuClient.ensureCredentials() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Ensuring the sensu clustername is more clear than 'name'
Ensuring the sensu cluster exists prior to interacting with sensu cluster for CRD ops
Ensuring that status of CRD is updated on success/ful
Additional tests

PLAT-4598