### PR TITLE
Add RBAC to pod spec

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# each line is a file pattern followed by one or more owners.
+
+# sensu-operator
+* @objectrocket/platform

--- a/helm/sensu-operator/templates/sensu-operator-deployment.yaml
+++ b/helm/sensu-operator/templates/sensu-operator-deployment.yaml
@@ -25,6 +25,7 @@ spec:
       - name: sensu-operator
         image: {{ .Values.image.repository }}:{{ .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        serviceAccountName: {{ .Values.rbac.clusterRole }}
         ports:
         - containerPort: 8080
           name: http        

--- a/helm/sensu-operator/templates/sensu-operator-deployment.yaml
+++ b/helm/sensu-operator/templates/sensu-operator-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       - name: sensu-operator
         image: {{ .Values.image.repository }}:{{ .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        serviceAccountName: {{ .Values.rbac.clusterRole }}
+        serviceAccountName: {{ .Release.Name }}
         ports:
         - containerPort: 8080
           name: http        

--- a/helm/sensu-operator/templates/sensu-operator-rbac.yaml
+++ b/helm/sensu-operator/templates/sensu-operator-rbac.yaml
@@ -1,4 +1,12 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+...
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.rbac.clusterRole }}-binding
@@ -8,10 +16,10 @@ roleRef:
   name: {{ .Values.rbac.clusterRole }}
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ Release.Name }}
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Values.rbac.clusterRole }}


### PR DESCRIPTION
Previously we were binding the operator role to the default service account instead of creating one specifically for the operator. This makes it easier to reason about and lets us be more granular with which pods have which permissions.

Also adds code owners so we can start requiring approvals