### PR TITLE
Make filters not mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,13 @@ KUBECONFIG=~/.kube/config \
 ```
 
 [k8s-home]: http://kubernetes.io
+
+## Development
+
+### OpenAPI specs
+
+We use automatically generated OpenAPI specs for our custom resource definitions. If you make changes to the types, you can run this to regenerate specs:
+
+```console
+./hack/k8s/openapi-gen/openapi-gen.sh 
+```

--- a/README.md
+++ b/README.md
@@ -224,5 +224,5 @@ KUBECONFIG=~/.kube/config \
 We use automatically generated OpenAPI specs for our custom resource definitions. If you make changes to the types, you can run this to regenerate specs:
 
 ```console
-./hack/k8s/openapi-gen/openapi-gen.sh 
+./hack/k8s/openapi-gen/openapi-gen.sh
 ```

--- a/pkg/apis/objectrocket/v1beta1/asset.go
+++ b/pkg/apis/objectrocket/v1beta1/asset.go
@@ -56,7 +56,7 @@ type SensuAssetSpec struct {
 	// Filters are a collection of sensu queries, used by the system to determine
 	// if the asset should be installed. If more than one filter is present the
 	// queries are joined by the "AND" operator.
-	Filters []string `json:"filters"`
+	Filters []string `json:"filters,omitempty"`
 
 	// Organization indicates to which org an asset belongs to
 	Organization string `json:"organization,omitempty"`

--- a/pkg/apis/objectrocket/v1beta1/check_config.go
+++ b/pkg/apis/objectrocket/v1beta1/check_config.go
@@ -86,10 +86,10 @@ type SensuCheckConfigSpec struct {
 	RoundRobin bool `json:"roundRobin,omitempty"`
 	// OutputOutputMetricFormat is the metric protocol that the check's output will be
 	// expected to follow in order to be extracted.
-	OutputMetricFormat string `json:"outputMetric_format,omitempty"`
+	OutputMetricFormat string `json:"outputMetricFormat,omitempty"`
 	// OutputOutputMetricHandlers is the list of event handlers that will respond to metrics
 	// that have been extracted from the check.
-	OutputMetricHandlers []string `json:"outputMetric_handlers,omitempty"`
+	OutputMetricHandlers []string `json:"outputMetricHandlers,omitempty"`
 	// EnvVars is the list of environment variables to set for the check's
 	// execution environment.
 	EnvVars []string `json:"envVars,omitempty"`

--- a/pkg/apis/objectrocket/v1beta1/openapi_generated.go
+++ b/pkg/apis/objectrocket/v1beta1/openapi_generated.go
@@ -133,7 +133,7 @@ func schema_pkg_apis_objectrocket_v1beta1_SensuAssetSpec(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"filters", "sensuMetadata"},
+				Required: []string{"sensuMetadata"},
 			},
 		},
 		Dependencies: []string{
@@ -337,14 +337,14 @@ func schema_pkg_apis_objectrocket_v1beta1_SensuCheckConfigSpec(ref common.Refere
 							Format:      "",
 						},
 					},
-					"outputMetric_format": {
+					"outputMetricFormat": {
 						SchemaProps: spec.SchemaProps{
 							Description: "OutputOutputMetricFormat is the metric protocol that the check's output will be expected to follow in order to be extracted.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
-					"outputMetric_handlers": {
+					"outputMetricHandlers": {
 						SchemaProps: spec.SchemaProps{
 							Description: "OutputOutputMetricHandlers is the list of event handlers that will respond to metrics that have been extracted from the check.",
 							Type:        []string{"array"},


### PR DESCRIPTION
We were just passing empty filter lists in our assets, so made it not mandatory

Also made two field names consistently camelCased since it was throwing warnings before that
```
jona6023@MRQ02JGQR4 sensu-operator (filterremove)*$ ./hack/k8s/openapi-gen/openapi-gen.sh 
go build -o _output/openapi-gen ./vendor/k8s.io/kube-openapi/cmd/openapi-gen/openapi-gen.go
API rule violation: names_match,github.com/objectrocket/sensu-operator/pkg/apis/objectrocket/v1beta1,SensuCheckConfigSpec,OutputMetricFormat
API rule violation: names_match,github.com/objectrocket/sensu-operator/pkg/apis/objectrocket/v1beta1,SensuCheckConfigSpec,OutputMetricHandlers
2019/01/22 16:49:37 Code for OpenAPI definitions generated
```