### PR TITLE
Support multiple sensu servers/backends

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
     docker:
       - image: circleci/python:3.6
     environment:
-      DESIRED_VERSION: "v2.9.1"
+      DESIRED_VERSION: "v2.11.0"
     steps:
       - checkout
       - run:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ ws://example-sensu-cluster-agent.sensu.svc.cluster.local:8081
 If needed, login into the sensu backend UI:
 
 ```bash
-$ kubectl -n sensu port-forward pod/platdev0-0 3000:3000
+$ kubectl -n sensu port-forward service/platdev0-dashboard 3000:3000
 Forwarding from 127.0.0.1:3000 -> 3000
 Forwarding from [::1]:3000 -> 3000
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ kubectl apply -f example/deployment.yaml
 You should end up with 1 running pods, e.g.:
 
 ```bash
-$ kubectl get pods -l name=sensu-operator
+$ kubectl -n sensu get pods -l name=sensu-operator
 NAME                              READY     STATUS    RESTARTS   AGE
 sensu-operator-6444f68845-54bvs   1/1       Running   0          1m
 ```
@@ -79,7 +79,7 @@ ws://example-sensu-cluster-agent.sensu.svc.cluster.local:8081
 If needed, login into the sensu backend UI:
 
 ```bash
-kubectl -n sensu port-forward pod/platdev0-0 3000:3000
+$ kubectl -n sensu port-forward pod/platdev0-0 3000:3000
 Forwarding from 127.0.0.1:3000 -> 3000
 Forwarding from [::1]:3000 -> 3000
 ```

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -535,3 +535,23 @@ func (c *Cluster) logSpecUpdate(oldSpec, newSpec api.ClusterSpec) {
 	}
 
 }
+
+func (c *Cluster) memberName(num int) string {
+	return fmt.Sprintf("%s-%d", c.name(), num)
+}
+
+func (c *Cluster) ClientURLs(m *etcdutil.MemberConfig) (urls []string) {
+	for i := 0; i < c.status.Size; i++ {
+		urls = append(urls, c.PeerURL(m, i))
+	}
+	return
+}
+
+func (c *Cluster) PeerURL(m *etcdutil.MemberConfig, ordinalID int) string {
+	return fmt.Sprintf("%s://%s.%s.%s.svc:2380",
+		m.PeerScheme(),
+		c.memberName(ordinalID),
+		c.name(),
+		c.cluster.Namespace,
+	)
+}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -371,13 +371,6 @@ func (c *Cluster) createStatefulSet(m *etcdutil.MemberConfig) error {
 	set := k8sutil.NewSensuStatefulSet(m, c.cluster.Name, uuid.New(), c.cluster.Spec, c.cluster.AsOwner())
 	if c.isPodPVEnabled() {
 		pvc := k8sutil.NewSensuPodPVC(m, *c.cluster.Spec.Pod.PersistentVolumeClaimSpec, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())
-		// _, err = c.config.KubeCli.CoreV1().PersistentVolumeClaims(c.cluster.Namespace).Create(pvc)
-		// if err != nil {
-		// 	return fmt.Errorf("failed to create PVC for member (%s): %v", c.cluster.Name, err)
-		// }
-		// k8sutil.AddEtcdVolumeToPod(&set.Spec.Template, pvc)
-		// pvcTemplate := k8sutil.NewSenuPVCTemplate()
-		// k8sutil.AddEtcdVolumeTemplate(&set, pvcTemplate)
 		set.Spec.VolumeClaimTemplates = append(set.Spec.VolumeClaimTemplates, *pvc)
 	} else {
 		k8sutil.AddEtcdVolumeToPod(&set.Spec.Template, nil)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -371,11 +371,14 @@ func (c *Cluster) createStatefulSet(m *etcdutil.MemberConfig) error {
 	set := k8sutil.NewSensuStatefulSet(m, c.cluster.Name, uuid.New(), c.cluster.Spec, c.cluster.AsOwner())
 	if c.isPodPVEnabled() {
 		pvc := k8sutil.NewSensuPodPVC(m, *c.cluster.Spec.Pod.PersistentVolumeClaimSpec, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())
-		_, err = c.config.KubeCli.CoreV1().PersistentVolumeClaims(c.cluster.Namespace).Create(pvc)
-		if err != nil {
-			return fmt.Errorf("failed to create PVC for member (%s): %v", c.cluster.Name, err)
-		}
-		k8sutil.AddEtcdVolumeToPod(&set.Spec.Template, pvc)
+		// _, err = c.config.KubeCli.CoreV1().PersistentVolumeClaims(c.cluster.Namespace).Create(pvc)
+		// if err != nil {
+		// 	return fmt.Errorf("failed to create PVC for member (%s): %v", c.cluster.Name, err)
+		// }
+		// k8sutil.AddEtcdVolumeToPod(&set.Spec.Template, pvc)
+		// pvcTemplate := k8sutil.NewSenuPVCTemplate()
+		// k8sutil.AddEtcdVolumeTemplate(&set, pvcTemplate)
+		set.Spec.VolumeClaimTemplates = append(set.Spec.VolumeClaimTemplates, *pvc)
 	} else {
 		k8sutil.AddEtcdVolumeToPod(&set.Spec.Template, nil)
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -32,7 +32,7 @@ import (
 	"github.com/onrik/logrus/filename"
 	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,7 +82,7 @@ type Cluster struct {
 	tlsConfig *tls.Config
 
 	eventsCli   corev1.EventInterface
-	statefulSet *appsv1beta1.StatefulSet
+	statefulSet *appsv1.StatefulSet
 }
 
 // New makes a new cluster
@@ -382,7 +382,7 @@ func (c *Cluster) createStatefulSet(m *etcdutil.MemberConfig) error {
 	} else {
 		k8sutil.AddEtcdVolumeToPod(&set.Spec.Template, nil)
 	}
-	c.statefulSet, err = c.config.KubeCli.AppsV1beta1().StatefulSets(c.cluster.Namespace).Create(set)
+	c.statefulSet, err = c.config.KubeCli.AppsV1().StatefulSets(c.cluster.Namespace).Create(set)
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func (c *Cluster) pollPods() (running, pending []*v1.Pod, err error) {
 		return nil, nil, fmt.Errorf("failed to list running pods: %v", err)
 	}
 
-	set, err := c.config.KubeCli.AppsV1beta1().StatefulSets(c.cluster.Namespace).Get(c.cluster.Name, metav1.GetOptions{})
+	set, err := c.config.KubeCli.AppsV1().StatefulSets(c.cluster.Namespace).Get(c.cluster.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to fetch new StatefulSet: %v", err)
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -249,8 +249,8 @@ func (c *Cluster) run() {
 
 			if len(notready) > 0 {
 				// Pod startup might take long, e.g. pulling image. It would deterministically become running or succeeded/failed later.
-				c.logger.Infof("skip reconciliation: running (%v), pending (%v)", k8sutil.GetPodNames(ready), k8sutil.GetPodNames(notready))
-				reconcileFailed.WithLabelValues("not all pods are running").Inc()
+				c.logger.Infof("skip reconciliation: ready (%v), not ready (%v)", k8sutil.GetPodNames(ready), k8sutil.GetPodNames(notready))
+				reconcileFailed.WithLabelValues("not all pods are ready").Inc()
 				continue
 			}
 			if len(ready) == 0 {
@@ -319,7 +319,7 @@ func (c *Cluster) startStatefulSet() error {
 		return fmt.Errorf("failed to create statefulset (%s): %v", c.cluster.Name, err)
 	}
 
-	c.logger.Infof("cluster created with seed member (%s)", c.cluster.Name)
+	c.logger.Infof("cluster created with seed member (%s-0)", c.cluster.Name)
 	_, err := c.eventsCli.Create(k8sutil.NewMemberAddEvent(c.cluster))
 	if err != nil {
 		c.logger.Errorf("failed to create new member add event: %v", err)

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -76,14 +76,13 @@ func (c *Cluster) reconcile(pods []*v1.Pod) error {
 	}
 	c.status.ClearCondition(api.ClusterConditionScaling)
 
-	sp := c.cluster.Spec
-	if needUpgrade(pods, sp) {
-		c.status.UpgradeVersionTo(sp.Version)
+	if needUpgrade(pods, c.cluster.Spec) {
+		c.status.UpgradeVersionTo(c.cluster.Spec.Version)
 		return c.upgradeStatefulSet()
 	}
 	c.status.ClearCondition(api.ClusterConditionUpgrading)
 
-	c.status.SetVersion(sp.Version)
+	c.status.SetVersion(c.cluster.Spec.Version)
 	c.status.SetReadyCondition()
 	return nil
 }

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -57,7 +57,7 @@ func (c *Cluster) reconcile(pods []*v1.Pod) error {
 			if err = c.addOneMember(affectedMember); err != nil {
 				return err
 			}
-		} else {
+		} else if int(*set.Spec.Replicas) > c.cluster.Spec.Size {
 			affectedMember = int(*set.Spec.Replicas - 1)
 			*set.Spec.Replicas--
 			if err = c.removeOneMember(affectedMember); err != nil {

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -32,7 +32,7 @@ var ErrLostQuorum = errors.New("lost quorum")
 func (c *Cluster) reconcile(pods []*v1.Pod) error {
 	if c.statefulSet.Spec.Replicas == nil {
 		c.logger.Infof("StatefulSet for cluster %s has nil Replicas.  Fetching new StatefulSet", c.name())
-		set, err := c.config.KubeCli.AppsV1beta1().StatefulSets(c.cluster.Namespace).Get(c.cluster.Name, metav1.GetOptions{})
+		set, err := c.config.KubeCli.AppsV1().StatefulSets(c.cluster.Namespace).Get(c.cluster.Name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("Failed to fetch new StatefulSet: %v", err)
 		}
@@ -41,12 +41,12 @@ func (c *Cluster) reconcile(pods []*v1.Pod) error {
 		return nil
 	}
 	if c.cluster.Spec.Size != int(*c.statefulSet.Spec.Replicas) {
-		set, err := c.config.KubeCli.AppsV1beta1().StatefulSets(c.cluster.Namespace).Get(c.cluster.Name, metav1.GetOptions{})
+		set, err := c.config.KubeCli.AppsV1().StatefulSets(c.cluster.Namespace).Get(c.cluster.Name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("Error getting StatefulSet %s for size update: %v", c.statefulSet.GetName(), err)
 		}
 		*set.Spec.Replicas = int32(c.cluster.Spec.Size)
-		set, err = c.config.KubeCli.AppsV1beta1().StatefulSets(c.cluster.Namespace).Update(set)
+		set, err = c.config.KubeCli.AppsV1().StatefulSets(c.cluster.Namespace).Update(set)
 		if err != nil {
 			return fmt.Errorf("Error updating StatefulSet %s size: %v", c.statefulSet.GetName(), err)
 		}

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -45,6 +45,7 @@ func (c *Cluster) reconcile(pods []*v1.Pod) error {
 		if err != nil {
 			return fmt.Errorf("Error getting StatefulSet %s for size update: %v", c.statefulSet.GetName(), err)
 		}
+		*set.Spec.Replicas = int32(c.cluster.Spec.Size)
 		set, err = c.config.KubeCli.AppsV1beta1().StatefulSets(c.cluster.Namespace).Update(set)
 		if err != nil {
 			return fmt.Errorf("Error updating StatefulSet %s size: %v", c.statefulSet.GetName(), err)

--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -67,6 +67,7 @@ func (c *Cluster) upgradeStatefulSet() error {
 		return nil
 	}
 	c.statefulSet.Spec.Template.Spec.Containers[0].Image = k8sutil.ImageName(c.cluster.Spec.Repository, c.cluster.Spec.Version)
+	k8sutil.SetPodTemplateSensuVersion(&c.statefulSet.Spec.Template, c.cluster.Spec.Version)
 	set, err := c.config.KubeCli.AppsV1().StatefulSets(c.cluster.Namespace).Update(c.statefulSet)
 	if err != nil {
 		return fmt.Errorf("failed to update sensu version in statefulset spec: %s", err)

--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -16,6 +16,7 @@ package cluster
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/objectrocket/sensu-operator/pkg/util/k8sutil"
 
@@ -54,5 +55,22 @@ func (c *Cluster) upgradeOneMember(memberName string) error {
 		c.logger.Errorf("failed to create member upgraded event: %v", err)
 	}
 
+	return nil
+}
+
+func (c *Cluster) upgradeStatefulSet() error {
+	c.status.SetUpgradingCondition(c.cluster.Spec.Version)
+
+	targetVersion := strings.Split(c.statefulSet.Spec.Template.Spec.Containers[0].Image, ":")[1]
+	if targetVersion == c.cluster.Spec.Version {
+		c.logger.Debugf("Waiting for StatefulSet rolling update")
+		return nil
+	}
+	c.statefulSet.Spec.Template.Spec.Containers[0].Image = k8sutil.ImageName(c.cluster.Spec.Repository, c.cluster.Spec.Version)
+	set, err := c.config.KubeCli.AppsV1().StatefulSets(c.cluster.Namespace).Update(c.statefulSet)
+	if err != nil {
+		return fmt.Errorf("failed to update sensu version in statefulset spec: %s", err)
+	}
+	c.statefulSet = set
 	return nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -154,7 +154,7 @@ func (c *Controller) handleClusterEvent(event *Event) (bool, error) {
 		}
 		c.clusters[clus.Name].Delete()
 		deletionPolicy := v1.DeletePropagationBackground
-		err = c.KubeCli.AppsV1beta1().StatefulSets(clus.GetNamespace()).Delete(clus.GetName(), &v1.DeleteOptions{
+		err = c.KubeCli.AppsV1().StatefulSets(clus.GetNamespace()).Delete(clus.GetName(), &v1.DeleteOptions{
 			PropagationPolicy: &deletionPolicy,
 		})
 		if err != nil {

--- a/pkg/util/etcdutil/member.go
+++ b/pkg/util/etcdutil/member.go
@@ -37,10 +37,11 @@ func (m *MemberConfig) ListenClientURL() string {
 
 // ListenPeerURL is the URL to listen on for peer connections
 func (m *MemberConfig) ListenPeerURL() string {
-	return fmt.Sprintf("%s://0.0.0.0:2380", m.peerScheme())
+	return fmt.Sprintf("%s://0.0.0.0:2380", m.PeerScheme())
 }
 
-func (m *MemberConfig) peerScheme() string {
+// PeerScheme returns http or https for the peer scheme
+func (m *MemberConfig) PeerScheme() string {
 	if m.SecurePeer {
 		return "https"
 	}

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -642,6 +642,7 @@ func NewSensuStatefulSet(m *etcdutil.MemberConfig, clusterName, token string, cs
 			},
 			Template:    *podTemplate,
 			ServiceName: clusterName,
+			Replicas:    newInt32(1),
 		},
 	}
 	return statefulSet
@@ -732,4 +733,9 @@ func UniqueMemberName(clusterName string) string {
 		clusterName = clusterName[:maxNameLength]
 	}
 	return clusterName + "-" + suffix
+}
+
+func newInt32(i int) *int32 {
+	var newI int32 = int32(i)
+	return &newI
 }

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -26,7 +26,7 @@ import (
 	"github.com/objectrocket/sensu-operator/pkg/util/etcdutil"
 	"github.com/objectrocket/sensu-operator/pkg/util/retryutil"
 
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -228,16 +228,16 @@ func CreateAndWaitPod(kubecli kubernetes.Interface, ns string, pod *v1.Pod, time
 
 // CreateAndWaitDeployment creates a deployment and waits until the defined
 // number of replicas is reached
-func CreateAndWaitDeployment(kubecli kubernetes.Interface, ns string, deployment *appsv1beta1.Deployment, timeout time.Duration) (*appsv1beta1.Deployment, error) {
-	deployment, err := kubecli.AppsV1beta1().Deployments(ns).Create(deployment)
+func CreateAndWaitDeployment(kubecli kubernetes.Interface, ns string, deployment *appsv1.Deployment, timeout time.Duration) (*appsv1.Deployment, error) {
+	deployment, err := kubecli.AppsV1().Deployments(ns).Create(deployment)
 	if err != nil {
 		return nil, err
 	}
 
 	interval := 5 * time.Second
-	var retDeployment *appsv1beta1.Deployment
+	var retDeployment *appsv1.Deployment
 	err = retryutil.Retry(interval, int(timeout/(interval)), func() (bool, error) {
-		retDeployment, err = kubecli.AppsV1beta1().Deployments(ns).Get(deployment.Name, metav1.GetOptions{})
+		retDeployment, err = kubecli.AppsV1().Deployments(ns).Get(deployment.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -628,15 +628,15 @@ func podSecurityContext(podPolicy *api.PodPolicy) *v1.PodSecurityContext {
 }
 
 // NewSensuStatefulSet creates a new StatefulSet for a Sensu cluster
-func NewSensuStatefulSet(m *etcdutil.MemberConfig, clusterName, token string, cs api.ClusterSpec, owner metav1.OwnerReference) *appsv1beta1.StatefulSet {
+func NewSensuStatefulSet(m *etcdutil.MemberConfig, clusterName, token string, cs api.ClusterSpec, owner metav1.OwnerReference) *appsv1.StatefulSet {
 	podTemplate := newSensuPodTemplate(m, clusterName, token, cs)
 	applyPodPolicy(clusterName, podTemplate, cs.Pod)
 	addOwnerRefToObject(podTemplate.GetObjectMeta(), owner)
-	statefulSet := &appsv1beta1.StatefulSet{
+	statefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterName,
 		},
-		Spec: appsv1beta1.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: podTemplate.ObjectMeta.Labels,
 			},

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -20,8 +20,8 @@ import (
 	api "github.com/objectrocket/sensu-operator/pkg/apis/objectrocket/v1beta1"
 	"github.com/objectrocket/sensu-operator/pkg/util/k8sutil"
 
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
-	"k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -87,13 +87,13 @@ func NewEtcdService(clusterName, serviceName string) *v1.Service {
 	}
 }
 
-func NewDummyDeployment(clusterName string) *appsv1beta1.Deployment {
+func NewDummyDeployment(clusterName string) *appsv1.Deployment {
 	replicas := int32(2)
-	return &appsv1beta1.Deployment{
+	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "dummy-service-",
 		},
-		Spec: appsv1beta1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/e2eutil/util.go
+++ b/test/e2e/e2eutil/util.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/objectrocket/sensu-operator/pkg/util/k8sutil"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -55,7 +55,7 @@ func DeleteDummyDeployment(kubecli kubernetes.Interface, nameSpace, name string)
 		GracePeriodSeconds: &gracePeriod,
 		PropagationPolicy:  &deletePolicy,
 	}
-	return kubecli.AppsV1beta1().Deployments(nameSpace).Delete(name, deleteOptions)
+	return kubecli.AppsV1().Deployments(nameSpace).Delete(name, deleteOptions)
 }
 
 func DeleteDummyPod(kubecli kubernetes.Interface, nameSpace, name string) error {


### PR DESCRIPTION
Modifies the k8s StatefulSet of sensu backends to support multiple pods. Changed the sensu config initContainer build etcd flags based on the ordinal number of the pod. Changed the etcd data PVC to be allocated in a volume claim template, so PVCs are named with ordinal numbers by the StatefulSet.

Scaling is handled by incrementing or decrementing the number of replicas in the StatefulSet one at a time, and adding/removing a member from etcd until the desired size is reached. Upgrades are handled by updating the StatefulSet with the new sensu image version and letting the StatefulSet rolling update occur.

Also updated k8s calls from using AppsV1Beta1 to AppsV1 to be compatible with k8s 1.16.

https://objectrocket.atlassian.net/browse/PLAT-6398