### PR TITLE
Plat 7734/reconcile sensu entities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-references: 
+references:
   platform-docker: &docker
     docker:
       - image: objectrocket/platform-cicd:latest
@@ -73,7 +73,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "69:52:7a:2e:29:b7:ba:aa:5e:59:98:14:f9:8b:d4:ae"   
+            - "69:52:7a:2e:29:b7:ba:aa:5e:59:98:14:f9:8b:d4:ae"
       - run:
           name: add helm repo
           command: ~/ci-scripts/helm_add_repo.sh
@@ -107,6 +107,7 @@ workflows:
             branches:
               ignore: /.*/
       - helm_push:
+          context: platform-eng
           requires:
             - build_deploy
           filters:
@@ -117,6 +118,7 @@ workflows:
             branches:
               ignore: /.*/
       - update-default:
+          context: platform-eng
           requires:
             - build_deploy
             - helm_push

--- a/example/dummy-agent-deployment.yaml
+++ b/example/dummy-agent-deployment.yaml
@@ -2,11 +2,13 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: dummy-service
+  namespace: sensu
 spec:
   replicas: 2
   template:
     metadata:
       name: dummy-service
+      namespace: sensu
       labels:
         app: dummy-service
     spec:
@@ -16,17 +18,14 @@ spec:
           command: ["/opt/sensu/bin/sensu-agent", "start"]
           env:
             - name: SENSU_BACKEND_URL
-              value: ws://example-sensu-cluster-agent.default.svc.cluster.local:8081
+              value: ws://platdev0-agent.sensu.svc.cluster.local:8081
             - name: SENSU_SUBSCRIPTIONS
               value: dummy
+            - name: SENSU_NAMESPACE
+              value: platform
+            - name: SENSU_DEREGISTER
+              value: "true"
+
         - name: dummy-service
           image: busybox
           command: ["/bin/sleep", "100000"]
-      nodeSelector:
-        node-role.kubernetes.io/platform_worker: "true"
-
-      tolerations:
-        - key: "node_role"
-          operator: "Equal"
-          value: "platform_worker"
-          effect: "NoSchedule"

--- a/example/example-sensu-cluster-objectrocket.yaml
+++ b/example/example-sensu-cluster-objectrocket.yaml
@@ -17,4 +17,4 @@ spec:
       storageClassName: standard
   repository: sensu/sensu
   size: 1
-  version: 5.13.1
+  version: 5.14.0

--- a/example/rbac/cluster-role-template.yaml
+++ b/example/rbac/cluster-role-template.yaml
@@ -29,6 +29,7 @@ rules:
   - endpoints
   - persistentvolumeclaims
   - events
+  - nodes
   verbs:
   - "*"
 - apiGroups:

--- a/example/rbac/role-template.yaml
+++ b/example/rbac/role-template.yaml
@@ -24,6 +24,7 @@ rules:
   - endpoints
   - persistentvolumeclaims
   - events
+  - nodes
   verbs:
   - "*"
 - apiGroups:

--- a/pkg/controller/informer.go
+++ b/pkg/controller/informer.go
@@ -248,7 +248,7 @@ func (c *Controller) runReconcile() {
 func (c *Controller) processReconcileItems() bool {
 	c.logger.Debugf("At processReconcileItems, initiating sync process")
 	c.reconcileSensuEntities()
-	time.Sleep(60 * time.Second)
+	time.Sleep(3 * time.Minute)
 	return true
 }
 

--- a/pkg/controller/informer.go
+++ b/pkg/controller/informer.go
@@ -129,6 +129,8 @@ func (c *Controller) startProcessing(ctx context.Context) {
 		go wait.Until(c.run, time.Second, ctx.Done())
 	}
 	c.logger.Debugf("done spawning %d worker threads", c.WorkerThreads)
+	c.logger.Debugf("Starting reconcile process on a single thread")
+	go wait.Until(c.runReconcile, time.Second, ctx.Done())
 	select {
 	case <-ctx.Done():
 	}
@@ -182,7 +184,7 @@ func (c *Controller) addInformer(namespace string, resourcePlural string, objTyp
 
 func (c *Controller) run() {
 	var wg sync.WaitGroup
-	wg.Add(5)
+	wg.Add(6)
 	go func() {
 		defer wg.Done()
 		defer c.informers[api.SensuClusterResourcePlural].queue.ShutDown()
@@ -228,6 +230,26 @@ func (c *Controller) run() {
 	c.logger.Debugf("waiting on all waitgroups to finish")
 	wg.Wait()
 	c.logger.Debugf("waitgroups finished")
+}
+
+func (c *Controller) runReconcile() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.logger.Debugf("starting reconcile k8s nodes <-> sensu entities")
+		for c.processReconcileItems() {
+		}
+	}()
+	c.logger.Debugf("reconcile waitgroups finished")
+	wg.Wait()
+}
+
+func (c *Controller) processReconcileItems() bool {
+	c.logger.Debugf("At processReconcileItems, initiating sync process")
+	c.reconcileSensuEntities()
+	time.Sleep(60 * time.Second)
+	return true
 }
 
 func (c *Controller) processNextClusterItem() bool {

--- a/pkg/controller/informer_k8s_node.go
+++ b/pkg/controller/informer_k8s_node.go
@@ -37,6 +37,7 @@ func (c *Controller) onDeleteNode(nodeName string) {
 	c.logger.Debugf("in onDeleteNode, end of func")
 }
 
-func (c *Controller) syncNode(*corev1.Node) {
+func (c *Controller) syncNode(node *corev1.Node) {
 	c.logger.Debugf("in syncNode, doing nothing")
+	c.logger.Debugf("node name %v", node.GetName())
 }

--- a/pkg/controller/reconcile_sensu_entities.go
+++ b/pkg/controller/reconcile_sensu_entities.go
@@ -1,0 +1,36 @@
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sensu_client "github.com/objectrocket/sensu-operator/pkg/sensu_client"
+)
+
+// Function to reconcile sensu entities
+func (c *Controller) reconcileSensuEntities() {
+	c.logger.Debugf("At reconcileSensuEntities, starting reconcile process")
+	nodes, err := c.Config.KubeCli.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+	// items := nodes.Items
+	for _, item := range nodes.Items {
+		c.logger.Debugf("At processReconcileItems, kubernetes node name: %v", item.Name)
+	}
+	for clusterName := range c.clusters {
+		if c.clusterExists(clusterName) {
+			c.logger.Debugf("Listing entities for sensu cluster: %v", clusterName)
+			// Being that the cluster nodes are *not* a CR, and don't have the metadata for the sensu namespace, and k8s namespace,
+			// we can only inspect the entities in the platform sensu namespace
+			sensuClient := sensu_client.New(clusterName, platformKubernetesNamespace, platformSensuNamespace)
+			entities, err := sensuClient.ListEntities(platformKubernetesNamespace)
+			if err != nil {
+				c.logger.Debugf("failed to list entities for sensu namespace: %v", platformKubernetesNamespace)
+				return
+			}
+			c.logger.Debugf("Found sensu entities: %v", entities)
+			return
+		}
+	}
+
+}

--- a/pkg/controller/reconcile_sensu_entities.go
+++ b/pkg/controller/reconcile_sensu_entities.go
@@ -4,33 +4,130 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	sensu_client "github.com/objectrocket/sensu-operator/pkg/sensu_client"
+	"strings"
+)
+
+var (
+	sensuEntitiesExclusions = [...]string{"sensu-common-cluster-agent"}
 )
 
 // Function to reconcile sensu entities
 func (c *Controller) reconcileSensuEntities() {
-	c.logger.Debugf("At reconcileSensuEntities, starting reconcile process")
-	nodes, err := c.Config.KubeCli.CoreV1().Nodes().List(metav1.ListOptions{})
-	if err != nil {
+	var (
+		nodes    []string
+		entities []string
+		err      error
+	)
+
+	if nodes, err = c.getK8sNodes(); err != nil {
+		c.logger.Debugf("At reconcileSensuEntities, could not get k8s nodes error: %v", err)
 		return
 	}
-	// items := nodes.Items
-	for _, item := range nodes.Items {
-		c.logger.Debugf("At processReconcileItems, kubernetes node name: %v", item.Name)
+	if entities, err = c.getSensuEntities(); err != nil {
+		c.logger.Debugf("At reconcileSensuEntities, could not get sensu entities error: %v", err)
+		return
 	}
+
+	c.logger.Debugf("At reconcileSensuEntities, starting reconcile process")
+	difference := c.calculateSensuEntitiesForRemoval(entities, nodes)
+	if len(difference) > 0 {
+		c.logger.Debugf("At reconcileSensuEntities, k8s nodes: %v", nodes)
+		c.logger.Debugf("At reconcileSensuEntities, sensu entities: %v", entities)
+		c.logger.Debugf("At reconcileSensuEntities, sensu entities for removal: %v", difference)
+		c.deleteSensuEntities(difference)
+	} else {
+		c.logger.Debugf("At reconcileSensuEntities, finish with no differences from k8s and sensu entities")
+	}
+
+	return
+}
+
+// getK8sNodes returns a slice of node names from kubernetes
+func (c *Controller) getK8sNodes() ([]string, error) {
+	nodes := []string{}
+	k8sNodes, err := c.Config.KubeCli.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range k8sNodes.Items {
+		nodes = append(nodes, item.Name)
+	}
+	return nodes, nil
+
+}
+
+// getSensuEntities returns a slice of node names from kubernetes
+func (c *Controller) getSensuEntities() ([]string, error) {
+	entities := []string{}
 	for clusterName := range c.clusters {
 		if c.clusterExists(clusterName) {
 			c.logger.Debugf("Listing entities for sensu cluster: %v", clusterName)
-			// Being that the cluster nodes are *not* a CR, and don't have the metadata for the sensu namespace, and k8s namespace,
-			// we can only inspect the entities in the platform sensu namespace
 			sensuClient := sensu_client.New(clusterName, platformKubernetesNamespace, platformSensuNamespace)
-			entities, err := sensuClient.ListEntities(platformKubernetesNamespace)
+			sensuEntities, err := sensuClient.ListEntities(platformSensuNamespace)
 			if err != nil {
-				c.logger.Debugf("failed to list entities for sensu namespace: %v", platformKubernetesNamespace)
-				return
+				c.logger.Debugf("Failed to list entities for sensu namespace: %v", platformSensuNamespace)
+				return nil, err
 			}
-			c.logger.Debugf("Found sensu entities: %v", entities)
-			return
+			if len(sensuEntities) == 0 {
+				c.logger.Debugf("List of entities from sensu is empty")
+				return nil, nil
+			}
+			for _, sensuEntity := range sensuEntities {
+				entities = append(entities, sensuEntity.GetName())
+			}
 		}
 	}
+	return entities, nil
 
+}
+
+// calculateSensuEntitiesForRemoval is used to return a slice of sensu entities not seen as kubernetes nodes,
+// and not in the list of exclusions.
+func (c *Controller) calculateSensuEntitiesForRemoval(entities []string, nodes []string) []string {
+	var diff []string
+
+	// find sensu entities not in kubernetes,
+	for i := 0; i < 1; i++ {
+		for _, s1 := range entities {
+			found := false
+			for _, s2 := range nodes {
+				if s1 == s2 {
+					found = true
+					break
+				}
+			}
+			// String not found. We add it to return slice only if not found in the list of exclusions
+			if !found {
+				excluded := false
+				for _, exclusion := range sensuEntitiesExclusions {
+					if strings.Contains(s1, exclusion) {
+						excluded = true
+						break
+					}
+				}
+				if !excluded {
+					diff = append(diff, s1)
+				}
+			}
+		}
+	}
+	return diff
+}
+
+// deleteSensuEntities takes an slice of sensu entities and removes them from sensu
+func (c *Controller) deleteSensuEntities(entities []string) {
+	for clusterName := range c.clusters {
+		if c.clusterExists(clusterName) {
+			sensuClient := sensu_client.New(clusterName, platformKubernetesNamespace, platformSensuNamespace)
+			for _, entitiy := range entities {
+				c.logger.Debugf("calling sensuClient.DeleteNode for %v", entitiy)
+				err := sensuClient.DeleteNode(entitiy)
+				if err != nil {
+					c.logger.Warningf("failed to handle node delete event: %v", err)
+					return
+				}
+			}
+
+		}
+	}
 }

--- a/pkg/controller/reconcile_sensu_entities_test.go
+++ b/pkg/controller/reconcile_sensu_entities_test.go
@@ -1,0 +1,148 @@
+package controller
+
+import (
+	"github.com/google/go-cmp/cmp"
+	api "github.com/objectrocket/sensu-operator/pkg/apis/objectrocket/v1beta1"
+	"github.com/objectrocket/sensu-operator/pkg/cluster"
+	fakesensu "github.com/objectrocket/sensu-operator/pkg/generated/clientset/versioned/fake"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	fakeapiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"testing"
+)
+
+func Test_calculateSensuEntitiesForRemoval(t *testing.T) {
+	assetInformer, checkInformer, handlerInformer, eventFilterInformer, nodeInformer := initInformers()
+	type fields struct {
+		logger     *logrus.Entry
+		Config     Config
+		informers  map[string]*Informer
+		finalizers map[string]cache.Indexer
+		clusters   map[string]*cluster.Cluster
+		nodes      []string
+		entities   []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		result []string
+		want   bool
+	}{
+		{
+			"test calculateSensuEntitiesForRemoval, returns entities not seen as k8s nodes",
+			fields{
+				logrus.WithField("pkg", "test"),
+				Config{
+					Namespace:         "testns",
+					ClusterWide:       true,
+					ServiceAccount:    "testsa",
+					KubeCli:           testclient.NewSimpleClientset(),
+					KubeExtCli:        fakeapiextensionsapiserver.NewSimpleClientset(),
+					SensuCRCli:        fakesensu.NewSimpleClientset(),
+					CreateCRD:         false,
+					WorkerThreads:     1,
+					ProcessingRetries: 0,
+				},
+				map[string]*Informer{},
+				map[string]cache.Indexer{},
+				map[string]*cluster.Cluster{},
+				[]string{"Node1", "Node2"},
+				[]string{"Entity1", "Entity2", "Node1", "Node2"},
+			},
+			[]string{"Entity1", "Entity2"},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Controller{
+				logger:     tt.fields.logger,
+				Config:     tt.fields.Config,
+				informers:  tt.fields.informers,
+				finalizers: tt.fields.finalizers,
+				clusters:   tt.fields.clusters,
+			}
+			c.informers[api.SensuAssetResourcePlural] = &assetInformer
+			c.informers[api.SensuCheckConfigResourcePlural] = &checkInformer
+			c.informers[api.SensuHandlerResourcePlural] = &handlerInformer
+			c.informers[api.SensuEventFilterResourcePlural] = &eventFilterInformer
+			c.informers[CoreV1NodesPlural] = &nodeInformer
+			response := c.calculateSensuEntitiesForRemoval(tt.fields.entities, tt.fields.nodes)
+			t.Logf("response: %v", response)
+			if got := cmp.Equal(tt.result, response); got != tt.want {
+				t.Errorf("equal() = calculateSensuEntitiesForRemoval equality issue, wanted %t, got %t: diff %s", tt.want, got, cmp.Diff(tt.result, response))
+			}
+		})
+	}
+}
+
+func Test_getK8sNodes(t *testing.T) {
+	assetInformer, checkInformer, handlerInformer, eventFilterInformer, nodeInformer := initInformers()
+	type fields struct {
+		logger     *logrus.Entry
+		Config     Config
+		informers  map[string]*Informer
+		finalizers map[string]cache.Indexer
+		clusters   map[string]*cluster.Cluster
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		result []string
+		nodes  *corev1.Node
+		want   bool
+	}{
+		{
+			"test getK8sNodes, returns nodes from k8s as an slice of strings with only the name",
+			fields{
+				logrus.WithField("pkg", "test"),
+				Config{
+					Namespace:         "testns",
+					ClusterWide:       true,
+					ServiceAccount:    "testsa",
+					KubeCli:           testclient.NewSimpleClientset(),
+					KubeExtCli:        fakeapiextensionsapiserver.NewSimpleClientset(),
+					SensuCRCli:        fakesensu.NewSimpleClientset(),
+					CreateCRD:         false,
+					WorkerThreads:     1,
+					ProcessingRetries: 0,
+				},
+				map[string]*Informer{},
+				map[string]cache.Indexer{},
+				map[string]*cluster.Cluster{},
+			},
+			[]string{"testinstance.localhost"},
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testinstance.localhost",
+				},
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Controller{
+				logger:     tt.fields.logger,
+				Config:     tt.fields.Config,
+				informers:  tt.fields.informers,
+				finalizers: tt.fields.finalizers,
+				clusters:   tt.fields.clusters,
+			}
+			c.informers[api.SensuAssetResourcePlural] = &assetInformer
+			c.informers[api.SensuCheckConfigResourcePlural] = &checkInformer
+			c.informers[api.SensuHandlerResourcePlural] = &handlerInformer
+			c.informers[api.SensuEventFilterResourcePlural] = &eventFilterInformer
+			c.informers[CoreV1NodesPlural] = &nodeInformer
+			c.Config.KubeCli.CoreV1().Nodes().Create(tt.nodes)
+			response, _ := c.getK8sNodes()
+			t.Logf("response: %v", response)
+			if got := cmp.Equal(response, tt.result); got != tt.want {
+				t.Errorf("equal() = getK8sNodes equality issue, wanted %t, got %t: diff %s", tt.want, got, cmp.Diff(response, tt.result))
+			}
+		})
+	}
+}

--- a/pkg/sensu_client/client.go
+++ b/pkg/sensu_client/client.go
@@ -48,7 +48,7 @@ func New(clusterName, namespace string, sensuNamespace string) *SensuClient {
 		namespace:   namespace,
 		timeout:     time.Duration(defaultTimeout),
 	}
-	sClient.logger.Debugf("Created new sensuClient with clusterName: %s, namespace %s", clusterName, namespace)
+	sClient.logger.Debugf("Created new sensuClient with clusterName: %s, namespace %s, sensu-namespace: %v", clusterName, namespace, sensuNamespace)
 	sClient.logger.Debugf("makeFullyQualifiedSensuClientURL returns: %s", sClient.makeFullyQualifiedSensuClientURL())
 	conf := basic.Config{
 		Cluster: basic.Cluster{

--- a/pkg/sensu_client/k8s_node.go
+++ b/pkg/sensu_client/k8s_node.go
@@ -8,6 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	sensuclient "github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -18,6 +19,11 @@ const (
 type fetchEntityResponse struct {
 	entity *types.Entity
 	err    error
+}
+
+type fetchEntitiesResponse struct {
+	entities []types.Entity
+	err      error
 }
 
 // AddNode will do nothing on a k8s node being added/updated/reconciled, for now
@@ -36,6 +42,11 @@ func (s *SensuClient) DeleteNode(nodeName string) error {
 		return errors.Wrap(err, "failed to ensure credentials for sensu client")
 	}
 	return s.ensureDeleteNode(nodeName)
+}
+
+// ListEntities will list all the entities in sensu namespace
+func (s *SensuClient) ListEntities(namespace string) ([]types.Entity, error) {
+	return s.fetchEntities(namespace)
 }
 
 // ensureNode left here for future use, as we potentially want to cleanup any dangling entities
@@ -61,8 +72,8 @@ func (s *SensuClient) ensureDeleteNode(nodeName string) error {
 
 func (s *SensuClient) fetchEntity(nodeName string) (*types.Entity, error) {
 	var (
-		entity   *types.Entity
-		err      error
+		entity *types.Entity
+		err    error
 	)
 	c1 := make(chan fetchEntityResponse, 1)
 	go func() {
@@ -94,4 +105,37 @@ func (s *SensuClient) fetchEntity(nodeName string) (*types.Entity, error) {
 		return nil, errors.New("timeout from sensu server after 10 seconds")
 	}
 	return entity, nil
+}
+
+func (s *SensuClient) fetchEntities(namespace string) ([]types.Entity, error) {
+	var (
+		entities []types.Entity
+		err      error
+	)
+	c1 := make(chan fetchEntitiesResponse, 1)
+	go func() {
+		if entities, err = s.sensuCli.Client.ListEntities(namespace, &sensuclient.ListOptions{}); err != nil {
+			s.logger.Warnf("failed to retrieve entities from namespace %s, err: %+v", namespace, err)
+			c1 <- fetchEntitiesResponse{nil, errors.Wrapf(err, "failed to retrieve entities from namespace %s", namespace)}
+		}
+		if entities != nil {
+			s.logger.Debugf("found entities %v", entities)
+			c1 <- fetchEntitiesResponse{entities, nil}
+			return
+		}
+		s.logger.Debugf("No entities found for namespace %s", namespace)
+		c1 <- fetchEntitiesResponse{nil, nil}
+	}()
+
+	select {
+	case response := <-c1:
+		if response.err != nil {
+			return nil, response.err
+		}
+		entities = response.entities
+	case <-time.After(s.timeout):
+		s.logger.Warnf("timeout from sensu server after 10 seconds while trying to list entities")
+		return nil, errors.New("timeout from sensu server after 10 seconds while trying to list entities")
+	}
+	return entities, nil
 }

--- a/pkg/sensu_client/k8s_node.go
+++ b/pkg/sensu_client/k8s_node.go
@@ -31,6 +31,21 @@ func (s *SensuClient) AddNode(node *corev1.Node) error {
 	return s.ensureNode(node)
 }
 
+// GetNode will list an entitiy from sensu
+func (s *SensuClient) GetNode(nodeName string) (string, error) {
+	if err := s.ensureCredentials(); err != nil {
+		return "", errors.Wrap(err, "failed to ensure credentials for sensu client")
+	}
+	entity, err := s.fetchEntity(nodeName)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to find entity from node name %s", nodeName)
+	}
+	if entity == nil {
+		return "", errors.New(fmt.Sprintf("failed to find entity from node name %s; empty entity", nodeName))
+	}
+	return entity.GetName(), nil
+}
+
 // UpdateNode will do nothing on a k8s node being added/updated/reconciled, for now
 func (s *SensuClient) UpdateNode(node *corev1.Node) error {
 	return s.ensureNode(node)
@@ -46,6 +61,9 @@ func (s *SensuClient) DeleteNode(nodeName string) error {
 
 // ListEntities will list all the entities in sensu namespace
 func (s *SensuClient) ListEntities(namespace string) ([]types.Entity, error) {
+	if err := s.ensureCredentials(); err != nil {
+		return nil, errors.Wrap(err, "failed to ensure credentials for sensu client")
+	}
 	return s.fetchEntities(namespace)
 }
 


### PR DESCRIPTION
This PR adds a completely different reconcile process for the operator, every time delta (3 min) it compares the sensu entities against the nodes from kubernetes (also takes exclusions into account), then it calculates the difference (entities entries in sensu from old k8s nodes that couldn't be removed) and removes them from sensu. This logic is intended to keep the sensu entries in sync with k8s nodes, specially for cycle operations. Ex of logs determining a sensu reconcile needed:

`time="2019-12-16T19:48:49Z" level=debug msg="At reconcileSensuEntities, starting reconcile process" _source="controller/reconcile_sensu_entities.go:31" pkg=controller
time="2019-12-16T19:48:49Z" level=debug msg="At reconcileSensuEntities, k8s nodes: [ip-10-0-136-143.us-west-2.compute.internal ip-10-0-136-205.us-west-2.compute.internal ip-10-0-138-209.us-west-2.compute.internal ip-10-0-15-187.us-west-2.compute.internal ip-10-0-151-36.us-west-2.compute.internal ip-10-0-155-35.us-west-2.compute.internal ip-10-0-158-9.us-west-2.compute.internal ip-10-0-169-126.us-west-2.compute.internal ip-10-0-170-4.us-west-2.compute.internal ip-10-0-172-203.us-west-2.compute.internal ip-10-0-28-211.us-west-2.compute.internal ip-10-0-40-174.us-west-2.compute.internal]" _source="controller/reconcile_sensu_entities.go:34" pkg=controller
time="2019-12-16T19:48:49Z" level=debug msg="At reconcileSensuEntities, sensu entities: [ip-10-0-136-143.us-west-2.compute.internal ip-10-0-136-205.us-west-2.compute.internal ip-10-0-138-209.us-west-2.compute.internal ip-10-0-149-208.us-west-2.compute.internal ip-10-0-15-187.us-west-2.compute.internal ip-10-0-151-36.us-west-2.compute.internal ip-10-0-155-35.us-west-2.compute.internal ip-10-0-158-9.us-west-2.compute.internal ip-10-0-162-159.us-west-2.compute.internal ip-10-0-169-126.us-west-2.compute.internal ip-10-0-170-4.us-west-2.compute.internal ip-10-0-172-203.us-west-2.compute.internal ip-10-0-28-211.us-west-2.compute.internal ip-10-0-40-174.us-west-2.compute.internal or-sensu-common-cluster-agent-584cbcf6d4-llqx6]" _source="controller/reconcile_sensu_entities.go:35" pkg=controller
time="2019-12-16T19:48:49Z" level=debug msg="At reconcileSensuEntities, sensu entities for removal: [ip-10-0-149-208.us-west-2.compute.internal ip-10-0-162-159.us-west-2.compute.internal]" _source="controller/reconcile_sensu_entities.go:36" pkg=controller`