### PR TITLE
Update job filters for tests to ignore master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,27 +114,18 @@ workflows:
   # runs on all commits
   build_and_test:
     jobs:
-      - build
-      - unit_test
-      - markdownlint
-  test_build_deploy:
-    jobs:
+      - markdownlint:
+          filters:
+            branches:
+              ignore: master
       - unit_test:
           filters:
-            tags:
-              only:
-                - /^[0-9]+.[0-9]+.[0-9]+$/
-                - /^[0-9]+.[0-9]+.[0-9]+-rc[0-9]+$/
             branches:
-              ignore: /.*/
+              ignore: master
       - build:
           filters:
-            tags:
-              only:
-                - /^[0-9]+.[0-9]+.[0-9]+$/
-                - /^[0-9]+.[0-9]+.[0-9]+-rc[0-9]+$/
             branches:
-              ignore: /.*/
+              ignore: master
   release:
     jobs:
       - create-release:


### PR DESCRIPTION
Ignoring testing on master branch, as it is redundant, since test are already run on the commit and PR prior to merging into master. 